### PR TITLE
[XAPID-377] Load apidAnalytics plugin as part of apid

### DIFF
--- a/cmd/apid/README.md
+++ b/cmd/apid/README.md
@@ -4,6 +4,7 @@
 * [ApigeeSync](https://github.com/30x/apidApigeeSync)
 * [VerifyAPIKey](https://github.com/30x/apidVerifyApiKey)
 * [GatewayDeploy](https://github.com/30x/apidGatewayDeploy)
+* [ApigeeAnalytics](https://github.com/30x/apidAnalytics)
 
 To change plugins list, edit main.go and update glide.yaml.
 

--- a/cmd/apid/apid_config_sample.yaml
+++ b/cmd/apid/apid_config_sample.yaml
@@ -9,3 +9,4 @@ apigeesync_snapshot_proto: json
 apigeesync_consumer_key: MDygyE8OD8rlemI7S1XhlUCA7jrarjxl
 apigeesync_consumer_secret: oAuKUqRVvFVq0tzS
 apigeesync_cluster_id: fc0e5137-d3fa-4017-8bfa-86b1103bc85d
+apidanalytics_uap_server_base: http://local.com:9001/edgex

--- a/cmd/apid/glide.yaml
+++ b/cmd/apid/glide.yaml
@@ -8,3 +8,5 @@ import:
   version: master
 - package: github.com/30x/apidVerifyAPIKey
   version: master
+- package: github.com/30x/apidAnalytics
+  version: master

--- a/cmd/apid/main.go
+++ b/cmd/apid/main.go
@@ -5,6 +5,7 @@ import (
 	_ "github.com/30x/apidApigeeSync"
 	_ "github.com/30x/apidVerifyAPIKey"
 	_ "github.com/30x/apidGatewayDeploy"
+	_ "github.com/30x/apidAnalytics"
 
 	// other imports
 	"github.com/30x/apid"


### PR DESCRIPTION
This change will load apidAnalytics plugin as part of apid from now. 

There is one required config that needs to be set else apid will crash after this change.

`apidanalytics_uap_server_base: https://edgex-internal-prod.e2e.apigee.net/edgex`