### PR TITLE
Add some scripts for a CI tool

### DIFF
--- a/tools/internal_ci/README.md
+++ b/tools/internal_ci/README.md
@@ -1,0 +1,4 @@
+# SCM
+
+This file contains some scripts and configuration files for use with an
+internal CI system.

--- a/tools/internal_ci/linux/apid_continuous.cfg
+++ b/tools/internal_ci/linux/apid_continuous.cfg
@@ -1,0 +1,3 @@
+build_file: "apid/tools/internal_ci/linux/test.sh"
+timeout_mins: 30
+

--- a/tools/internal_ci/linux/apid_release.cfg
+++ b/tools/internal_ci/linux/apid_release.cfg
@@ -1,0 +1,7 @@
+build_file: "apid/tools/internal_ci/linux/build.sh"
+timeout_mins: 30
+action {
+  define_artifacts {
+    regex: "apid"
+  }
+}

--- a/tools/internal_ci/linux/build.sh
+++ b/tools/internal_ci/linux/build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+BUILDROOT=${BUILDROOT:-git/apid}
+export BUILDROOT
+
+# Make a temporary GOPATH to build in
+gobase=`mktemp -d`
+GOPATH=${gobase}
+export GOPATH
+
+go get github.com/Masterminds/glide
+
+base=${gobase}/src/github.com/30x/apid
+mkdir -p ${base}
+(cd ${BUILDROOT}; tar cf - .) | (cd ${base}; tar xf -)
+
+set +x
+
+(cd ${base}; ${GOPATH}/bin/glide install)
+(cd ${base}; go build -o apid ./cmd/apid)
+buildResult=$?
+
+cp ${base}/apid .
+
+rm -rf ${gobase}
+
+exit ${buildResult}

--- a/tools/internal_ci/linux/test.sh
+++ b/tools/internal_ci/linux/test.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+BUILDROOT=${BUILDROOT:-git/apid}
+export BUILDROOT
+
+# Make a temporary GOPATH to build in
+gobase=`mktemp -d`
+GOPATH=${gobase}
+export GOPATH
+
+go get github.com/Masterminds/glide
+
+base=${gobase}/src/github.com/30x/apid
+mkdir -p ${base}
+(cd ${BUILDROOT}; tar cf - .) | (cd ${base}; tar xf -)
+
+(cd ${base}; ${GOPATH}/bin/glide install)
+(cd ${base}; go test ./api ./config ./events ./factory ./logger)
+testResult=$?
+
+if [ $testResult -eq 0 ]
+then 
+  echo "Building apid binary"
+  (cd ${base}; go build ./cmd/apid)
+  testResult=$?
+fi
+
+rm -rf ${gobase}
+
+exit ${testResult}


### PR DESCRIPTION
These scripts will allow us to build and test apid using an internal CI tool. (At some future
date we might be able to move them into an internal code repo but not today.)
